### PR TITLE
Troubleshoot vite command not found error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
-# Only for server-side environments (never expose in frontend)
-SUPABASE_SERVICE_ROLE_KEY=
+VITE_MT5_BRIDGE_URL=http://localhost:8001

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Create a `.env` file based on `.env.example` and set:
 ```
 VITE_SUPABASE_URL=your_project_url
 VITE_SUPABASE_ANON_KEY=your_anon_key
+VITE_MT5_BRIDGE_URL=<bridge_url_or_leave_default>
 ```
 
 Do not commit real keys. Never expose `SUPABASE_SERVICE_ROLE_KEY` in the frontend.

--- a/src/lib/trading/exnessApi.ts
+++ b/src/lib/trading/exnessApi.ts
@@ -64,8 +64,8 @@ class ExnessAPI {
   private connectionInfo: any = null;
   private lastUpdate: Date = new Date();
 
-  // MT5 Bridge URL - should point to your local Python service
-  private readonly MT5_BRIDGE_URL = 'http://localhost:8001';
+  // MT5 Bridge URL - prefer environment override, fallback to localhost
+  private readonly MT5_BRIDGE_URL: string = (import.meta.env.VITE_MT5_BRIDGE_URL as string) || 'http://localhost:8001';
 
   async connect(credentials: ExnessCredentials): Promise<boolean> {
     try {


### PR DESCRIPTION
Allow MT5 bridge URL to be configured via `VITE_MT5_BRIDGE_URL` environment variable.

This enables connecting to a remote MT5 bridge service, which is necessary when the frontend is deployed (e.g., via Lovable) and the bridge is running on a different machine or exposed via a tunnel like ngrok.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f30b21e-1762-46af-a7ea-70e4f2dc311a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f30b21e-1762-46af-a7ea-70e4f2dc311a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

